### PR TITLE
Add AppDbContext class for database context management

### DIFF
--- a/Backend/Data/AppDbContext.cs
+++ b/Backend/Data/AppDbContext.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Backend.Models;
+
+namespace Backend.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+        public DbSet<User> Users { get; set; }
+        public DbSet<Job> Jobs { get; set; }
+        public DbSet<Match> Matches { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Job>()
+                .HasOne(j => j.Employer)
+                .WithMany()
+                .HasForeignKey(j => j.EmployerId);
+
+            modelBuilder.Entity<Match>()
+                .HasOne(m => m.User)
+                .WithMany()
+                .HasForeignKey(m => m.UserId);
+
+            modelBuilder.Entity<Match>()
+                .HasOne(m => m.Job)
+                .WithMany()
+                .HasForeignKey(m => m.JobId);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `AppDbContext` class to the backend, establishing the Entity Framework Core data context for the application. The class defines database sets for `User`, `Job`, and `Match` entities, and configures their relationships using the Fluent API.

Key additions:

**Database context setup:**
* Added `AppDbContext` class in `Backend/Data/AppDbContext.cs`, inheriting from `DbContext` and defining `DbSet` properties for `User`, `Job`, and `Match` entities.

**Entity relationships:**
* Configured relationships:  
  - Each `Job` references an `Employer` via `EmployerId` (foreign key).  
  - Each `Match` references both a `User` and a `Job` via their respective foreign keys.